### PR TITLE
fix  #1【ファイルアップロード】値が空のときにgetメソッドで正しく空が返らない問題を解決

### DIFF
--- a/Plugin/CuCfFile/View/Helper/CuCfFileHelper.php
+++ b/Plugin/CuCfFile/View/Helper/CuCfFileHelper.php
@@ -102,7 +102,7 @@ class CuCfFileHelper extends AppHelper {
 					$data = $this->fileLink($fieldValue, $options);
 				}
 			} elseif($options['output'] === 'url') {
-				$data = $this->saveUrl . $fieldValue;
+				$data = is_string($fieldValue) ? $this->saveUrl . $fieldValue : '';
 			} else {
 				$data = $fieldValue;
 			}


### PR DESCRIPTION
@ryuring 

こちら、ご確認の上マージをお願いできますでしょうか？