### PR TITLE
fix #4 他のプラグインのコントローラなどで、$this->BlogPost->find()やpaginate()が失敗する問題を解決

### DIFF
--- a/Config/setting.php
+++ b/Config/setting.php
@@ -78,3 +78,9 @@ $config['cuCustomField'] = [
 $config['cuCustomFieldConfig'] = [
 	'submenu' => false
 ];
+
+/**
+ * blogBlogPostBeforeFind
+ * 最近の投稿、ブログ記事前後移動を find する際に実行するかどうか
+ */
+$config['customSearch'] = true;

--- a/Config/setting.php
+++ b/Config/setting.php
@@ -74,6 +74,8 @@ $config['cuCustomField'] = [
 /**
  * カスタムフィールド管理画面表示用設定
  *
+ * submenu	bool
+ * customSearch	bool : 最近の投稿、ブログ記事前後移動を find する際に実行するかどうか
  */
 $config['cuCustomFieldConfig'] = [
 	'submenu' => false,

--- a/Config/setting.php
+++ b/Config/setting.php
@@ -76,11 +76,6 @@ $config['cuCustomField'] = [
  *
  */
 $config['cuCustomFieldConfig'] = [
-	'submenu' => false
+	'submenu' => false,
+	'customSearch' => true
 ];
-
-/**
- * blogBlogPostBeforeFind
- * 最近の投稿、ブログ記事前後移動を find する際に実行するかどうか
- */
-$config['customSearch'] = true;

--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -99,7 +99,7 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 			}
 		}
 		$request = Router::getRequest();
-		$customSearch = Configure::read('customSearch');
+		$customSearch = Configure::read('cuCustomFieldConfig.customSearch');
 		if(isset($event->data[0]['customSearch']) && $event->data[0]['customSearch'] === false) {
 			$customSearch = false;
 		}

--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -99,7 +99,7 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 			}
 		}
 		$request = Router::getRequest();
-		$customSearch = true;
+		$customSearch = Configure::read('customSearch');
 		if(isset($event->data[0]['customSearch']) && $event->data[0]['customSearch'] === false) {
 			$customSearch = false;
 		}


### PR DESCRIPTION
@ryuring 

customSearchは、他のカスタマイズに与える影響範囲が大きいため、
使用するかしないかはConfig/setting.phpで切り替えできるようにしています。

こちら、ご確認お願いできませんでしょうか？