### PR TITLE
fix  #9 customSearchを無効にするとプレビューが使えなくなる問題を解決

### DIFF
--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -126,14 +126,14 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 			if($key === 'preview') {
 				continue;
 			}
-			if($value) {
+			if($value && !is_array($value)) {
 				$conditions[] = [
 					'key' => 'CuCustomFieldValue.' . $key,
 					'value LIKE' => '%' . $value . '%'
 				];
 			}
 		}
-		$query['conditions'] = $conditions;
+		$query['conditions'] = $query['conditions'] ? array_merge_recursive($query['conditions'], $conditions) : $conditions;
 		$query['joins'][] = [
 			'table' => 'cu_custom_field_values',
 			'alias' => 'CuCustomFieldValue',


### PR DESCRIPTION
@ryuring 

先程はありがとうございました。

修正コードにてプルリクをお送りいたします。
ご確認よろしくお願い申し上げます。