### PR TITLE
fix ファイルフィールドが空だとプレビューでエラーになる問題を解決

### DIFF
--- a/Plugin/CuCfFile/View/Helper/CuCfFileHelper.php
+++ b/Plugin/CuCfFile/View/Helper/CuCfFileHelper.php
@@ -95,7 +95,7 @@ class CuCfFileHelper extends AppHelper {
 				if(!empty($fieldValue['session_key'])) {
 					$checkValue = $fieldValue['session_key'];
 				}
-				if(in_array(pathinfo($checkValue, PATHINFO_EXTENSION), ['png', 'gif', 'jpeg', 'jpg'])) {
+				if(is_string($checkValue) && in_array(pathinfo($checkValue, PATHINFO_EXTENSION), ['png', 'gif', 'jpeg', 'jpg'])) {
 					$data = $this->uploadImage($fieldValue, $options);
 				} else {
 					$options['label'] = $fieldDefinition['name'];
@@ -158,7 +158,7 @@ class CuCfFileHelper extends AppHelper {
 		$noValue = $options['novalue'];
 		$label = $options['label'];
 		unset($options['format'], $options['model'], $options['separator'], $options['novalue']);
-		if(!$fieldValue) {
+		if(!$fieldValue || !is_string($fieldValue)) {
 			return $noValue;
 		} else {
 			return $this->BcHtml->link($label, $this->saveUrl . $fieldValue, $options);


### PR DESCRIPTION
@ryuring 

空だと、配列が入ってくるため、判定を調整しました。