### PR TITLE
fix #14 CustomSearchが有効だと、複数タグ検索などのカスタマイズのページネーションの挙動がおかしくなる問題の解決

### DIFF
--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -111,7 +111,7 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 					'foreignKey' => 'relate_id',
 				]
 			]], false);
-			$event->data[0] = $this->customSearchQuery($event->data[0], $request->query);
+			$event->data[0]['customSearch'] = $this->customSearchQuery($event->data[0], $request->query);
 		}
 		return $event->data;
 	}

--- a/Plugin/CuCfFile/Event/CuCfFileControllerEventListener.php
+++ b/Plugin/CuCfFile/Event/CuCfFileControllerEventListener.php
@@ -54,6 +54,7 @@ class CuCfFileControllerEventListener extends BcControllerEventListener {
 		if(empty($controller->BcContents->preview)) {
 			return;
 		}
-		$controller->set('post', $controller->BlogPost->CuCustomFieldValue->saveTmpFile($controller->viewVars['post']));
+		$CuCustomFieldValue = ClassRegistry::init('CuCustomField.CuCustomFieldValue');
+		$controller->set('post', $CuCustomFieldValue->saveTmpFile($controller->viewVars['post']));
 	}
 }


### PR DESCRIPTION
・CustomSearchを無効にしてもプレビューが正常に動作するように調整

@ryuring 
先程はありがとうございます。
案件での対応を優先するため、一旦こちらでプルリクをお送りさせていただきます。

TODO: CustomSearchが有効でもページネーションにゴミがつかない方法の検討