### PR TITLE
fix #19 customSearchQuery 検索がLIKEのため、valueが1でも10でも同じ検索結果となる問題を解決

### DIFF
--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -114,7 +114,7 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 					continue;
 				}
 				// like検索の場合はkey:likeがついている
-				$checkKey = preg_replace('/\:like/', '', $key);
+				$checkKey = preg_replace('/\:like$/', '', $key);
 				// クエリがCuCustomFieldで使用されているkeyに含まれていれば$searchQueryの配列に追加
 				if(in_array($checkKey, $keyArray)) {
 					$searchQuery[$key] = $query;

--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -127,10 +127,19 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 				continue;
 			}
 			if($value && !is_array($value)) {
-				$conditions[] = [
-					'key' => 'CuCustomFieldValue.' . $key,
-					'value LIKE' => '%' . $value . '%'
-				];
+				if (strpos($value,'==') === false) {
+					$conditions[] = [
+						'key' => 'CuCustomFieldValue.' . $key,
+						'value LIKE' => '%' . $value . '%' // valueが1と10では同じ検索結果になる。
+					];
+				} else {
+					// 完全一致検索の場合は、?フィールドキー===フィールドバリューで入力する
+					$value = str_replace('==', '', $value);
+					$conditions[] = [
+						'key' => 'CuCustomFieldValue.' . $key,
+						'value' => $value
+					];
+				}
 			}
 		}
 		$query['conditions'] = $query['conditions'] ? array_merge_recursive($query['conditions'], $conditions) : $conditions;


### PR DESCRIPTION
@ryuring
valueに「==」をつけた場合、完全一致で検索するという仕様で解決しようと思いますが、よろしいでしょうか？