### PR TITLE
fix #22 カスタムフィールドのデータがセットされていない記事のプレビューでnoticeが出る問題を解決

### DIFF
--- a/Plugin/CuCfFile/Model/Behavior/CuCfFileBehavior.php
+++ b/Plugin/CuCfFile/Model/Behavior/CuCfFileBehavior.php
@@ -384,7 +384,7 @@ class CuCfFileBehavior extends ModelBehavior
 	public function saveTmpFile(Model $Model, $data)
 	{
 		$this->Session->delete('Upload');
-		if($data['CuCustomFieldValue']) {
+		if(isset($data['CuCustomFieldValue']) && $data['CuCustomFieldValue']) {
 			foreach ($data['CuCustomFieldValue'] as $field => $value) {
 				$newDetail = [];
 				$section = 'CuCustomFieldValue';


### PR DESCRIPTION
@ryuring 
細かくてすみません。
こちらもご確認のうえ、マージお願いします。