### PR TITLE
Dev 4 fix #3 正規表現チェック選択時のエラー表示不具合修正

### DIFF
--- a/Model/CuCustomFieldDefinition.php
+++ b/Model/CuCustomFieldDefinition.php
@@ -138,6 +138,12 @@ class CuCustomFieldDefinition extends CuCustomFieldAppModel
 					'message' => 'フィールドタイプを選択してください。',
 				],
 			],
+			'validate_regex' => [
+				'checkValidateRegex' => [
+					'rule' => ['checkValidateRegex'],
+					'message' => '正規表現を入力してください。',
+				],
+			],
 		],
 	];
 
@@ -180,6 +186,23 @@ class CuCustomFieldDefinition extends CuCustomFieldAppModel
 			if (preg_match("/^[a-zA-Z0-9\_]+$/", $check[key($check)])) {
 				return true;
 			} else {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * 入力値チェック: 正規表現
+	 * 正規表現選択時に正規表現が入力されているかチェック
+	 *
+	 * @param array $check 対象データ
+	 * @return    boolean
+	 */
+	public function checkValidateRegex($check)
+	{
+		if (!empty($this->data[$this->alias]['validate']) && in_array('REGEX_CHECK', $this->data[$this->alias]['validate'])) {
+			if (empty($this->data[$this->alias][key($check)])) {
 				return false;
 			}
 		}
@@ -384,5 +407,4 @@ class CuCustomFieldDefinition extends CuCustomFieldAppModel
 			return true;
 		}
 	}
-
 }

--- a/View/Elements/admin/cu_custom_field_definitions/input_block/validate.php
+++ b/View/Elements/admin/cu_custom_field_definitions/input_block/validate.php
@@ -40,9 +40,6 @@
 						<li>エラーメッセージの指定がない場合は「入力エラーが発生しました。」となります。</li>
 					</ul>
 				</div>
-				<span id="CheckValueResultValidateRegex" class="display-none">
-					<div class="error-message duplicate-error-message">正規表現を入力してください。</div>
-				</span>
 				<?php echo $this->BcForm->error('CuCustomFieldDefinition.validate_regex') ?>
 				<br/>
 				<?php echo $this->BcForm->label('CuCustomFieldDefinition.validate_regex_message', 'エラー用文言') ?>

--- a/webroot/js/admin/cu_custom_field.js
+++ b/webroot/js/admin/cu_custom_field.js
@@ -68,18 +68,6 @@ $(function () {
         }
     });
 
-    // submit時の処理
-    btnSave.click(function () {
-        // 正規表現チェックが有効の場合に、正規表現入力欄が空の場合は submit させない
-        if (validateRegexCheck.prop('checked')) {
-            $validateRegex = validateRegex.val();
-            if (!$validateRegex) {
-                alert('正規表現入力欄が未入力です。');
-                return false;
-            }
-        }
-    });
-
     // 正規表現チェックのチェック時に、専用の入力欄を表示する
     validateRegexCheck.change(function () {
         $value = $(this).prop('checked');


### PR DESCRIPTION
[【テキストorテキストエリア】正規表現入力（必須）に任意の文字列を入力して保存後、空欄にして保存すると、「正規表現を入力してください。」と一瞬表示された後に空欄が保存されたまま一覧へ遷移する
](https://github.com/ecatchup/CuCustomField/issues/3)

こちらのissueの件、修正いたしました。
js での入力制御をはずし、model側にバリデーションを追加して対応しております。
お手数ですがご確認いただきマージいただけますと幸いです。

[backlog 課題　CU_WORK-1134 【CUカスタムフィールド】不具合対応](https://e-catchup.backlog.com/view/CU_WORK-1134#comment-80400663)


