### PR TITLE
fix #33 file以外のフィールドを使うとエラーが出る問題を解決

### DIFF
--- a/Event/CuCustomFieldModelEventListener.php
+++ b/Event/CuCustomFieldModelEventListener.php
@@ -506,13 +506,15 @@ class CuCustomFieldModelEventListener extends BcModelEventListener
 					'message' => ($definition['validate_regex_message']) ? $definition['validate_regex_message'] : '入力エラーが発生しました。',
 				],
 			],
-			'fileExt' => [
+		];
+		if (isset($definition['allow_file_exts'])) {
+			$validation['fileExt'] = [
 				'fileExt' => [
 					'rule' => ['fileExt', $definition['allow_file_exts']],
 					'message' => '許可されていないファイルです。',
 				],
-			],
-		];
+			];
+		}
 		return $validation[$rule];
 	}
 


### PR DESCRIPTION
@ryuring 
条件判定をつけました。

noticeエラーなので、緊急性は低いですが、
デバッグモードの場合、
ファイル以外のカスタムフィールドを使うと記事保存中にnoticeが出て、エラー画面で止まってしまうので、対応は必要かと思います。

宜しくおねがいします。