### PR TITLE
fix #38 CuCustomFieldを使っていないブログでプレビューしようとすると$dataの中身が空になって、プレビューにコンテン…

### DIFF
--- a/Plugin/CuCfFile/Model/Behavior/CuCfFileBehavior.php
+++ b/Plugin/CuCfFile/Model/Behavior/CuCfFileBehavior.php
@@ -300,7 +300,8 @@ class CuCfFileBehavior extends ModelBehavior
 			$entity = $data[$Model->alias];
 		} else {
 			$entity = $data;
-			$data = [];
+			$entity['id'] = !isset($entity['id']) ? $entity['BlogContent']['id'] : $entity['id'];
+			$data[$Model->alias] = [];
 		}
 		$this->setupFileUploader($Model, $data['BlogPost']['blog_content_id']);
 		$this->setupLoopFieldSettings($entity);


### PR DESCRIPTION
…ツが表示されなくなる問題を解決

@ryuring 
@gondoh 

空にする範囲を絞り込みました。
また、function setupLoopFieldSettings()にて$data['id']を参照するところがあるので、セットするように調整しています。

動作確認ずみです。

マージをお願いします。