### PR TITLE
設定一覧画面と詳細画面で、項目名称が異なっているため揃える調整

### DIFF
--- a/Model/CuCustomFieldDefinition.php
+++ b/Model/CuCustomFieldDefinition.php
@@ -86,7 +86,7 @@ class CuCustomFieldDefinition extends CuCustomFieldAppModel
 			'name' => [
 				'notBlank' => [
 					'rule' => ['notBlank'],
-					'message' => 'カスタムフィールド名を入力してください。',
+					'message' => '入力欄ラベルを入力してください。',
 					'required' => true,
 				],
 				'maxLength' => [
@@ -107,7 +107,7 @@ class CuCustomFieldDefinition extends CuCustomFieldAppModel
 			'field_name' => [
 				'notBlank' => [
 					'rule' => ['notBlank'],
-					'message' => 'フィールド名を入力してください。',
+					'message' => 'フィールド定義名を入力してください。',
 					'required' => true,
 				],
 				'maxLength' => [
@@ -129,7 +129,7 @@ class CuCustomFieldDefinition extends CuCustomFieldAppModel
 				],
 				[
 					'rule' => ['notInList', ['day']],
-					'message' => 'フィールド名に利用できない文字列です。変更してください。',
+					'message' => 'フィールド定義名に利用できない文字列です。変更してください。',
 				],
 			],
 			'field_type' => [

--- a/View/CuCustomFieldDefinitions/admin/form.php
+++ b/View/CuCustomFieldDefinitions/admin/form.php
@@ -41,7 +41,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 		['class' => 'bca-btn']
 	) ?>
 	&nbsp;&nbsp;
-	<small><?php echo $this->BcForm->input('show_field_name_list', ['type' => 'checkbox', 'label' => '現在利用しているフィールド名の一覧を表示']) ?></small>
+	<small><?php echo $this->BcForm->input('show_field_name_list', ['type' => 'checkbox', 'label' => '現在利用しているフィールド定義名の一覧を表示']) ?></small>
 </p>
 
 
@@ -82,7 +82,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 <?php endif ?>
 		<tr id="Row<?php echo $currentModelName . Inflector::camelize('field_name'); ?>">
 			<th class="col-head bca-form-table__label">
-				<?php echo $this->BcForm->label('CuCustomFieldDefinition.field_name', 'フィールド名') ?>&nbsp;<span
+				<?php echo $this->BcForm->label('CuCustomFieldDefinition.field_name', 'フィールド定義名') ?>&nbsp;<span
 					class="required bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span>
 			</th>
 			<td class="col-input bca-form-table__input" colspan="3">
@@ -91,18 +91,18 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 				<?php echo $this->BcForm->error('CuCustomFieldDefinition.field_name') ?>
 				<?php if ($this->request->action == 'admin_edit'): ?>
 				<p>
-					<span id="BeforeFieldNameComment">変更前のフィールド名：</span>
+					<span id="BeforeFieldNameComment">変更前のフィールド定義名：</span>
 					<span id="BeforeFieldName"><?php echo $this->BcForm->value('CuCustomFieldDefinition.field_name') ?></span>
 				</p>
 				<?php endif ?>
 				<div id="CheckValueResultFieldName" class="display-none">
-					<div class="error-message duplicate-error-message">同じフィールド名が存在します。変更してください。</div>
+					<div class="error-message duplicate-error-message">同じフィールド定義名が存在します。変更してください。</div>
 				</div>
 			</td>
 		</tr>
 		<tr id="Row<?php echo $currentModelName . Inflector::camelize('name'); ?>">
 			<th class="col-head bca-form-table__label">
-				<?php echo $this->BcForm->label('CuCustomFieldDefinition.name', 'フィールド定義名') ?>&nbsp;<span
+				<?php echo $this->BcForm->label('CuCustomFieldDefinition.name', '入力欄ラベル') ?>&nbsp;<span
 					class="required bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span>
 			</th>
 			<td class="col-input bca-form-table__input" colspan="3">

--- a/View/CuCustomFieldDefinitions/admin/form.php
+++ b/View/CuCustomFieldDefinitions/admin/form.php
@@ -110,7 +110,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 					['type' => 'text', 'size' => 60, 'maxlength' => 255, 'counter' => true, 'placeholder' => 'カスタムフィールドの入力欄に表示されるタイトルを入力してください']) ?>
 				<?php echo $this->BcForm->error('CuCustomFieldDefinition.name') ?>
 				<div id="CheckValueResultName" class="display-none">
-					<div class="error-message duplicate-error-message">同じカスタムフィールド名が存在します。変更してください。</div>
+					<div class="error-message duplicate-error-message">同じフィールド定義名が存在します。変更してください。</div>
 				</div>
 			</td>
 		</tr>

--- a/View/CuCustomFieldDefinitions/admin/form.php
+++ b/View/CuCustomFieldDefinitions/admin/form.php
@@ -41,7 +41,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 		['class' => 'bca-btn']
 	) ?>
 	&nbsp;&nbsp;
-	<small><?php echo $this->BcForm->input('show_field_name_list', ['type' => 'checkbox', 'label' => '現在利用しているフィールド定義の名称一覧を表示']) ?></small>
+	<small><?php echo $this->BcForm->input('show_field_name_list', ['type' => 'checkbox', 'label' => '現在利用しているフィールド名の一覧を表示']) ?></small>
 </p>
 
 
@@ -82,7 +82,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 <?php endif ?>
 		<tr id="Row<?php echo $currentModelName . Inflector::camelize('field_name'); ?>">
 			<th class="col-head bca-form-table__label">
-				<?php echo $this->BcForm->label('CuCustomFieldDefinition.field_name', 'フィールド定義名') ?>&nbsp;<span
+				<?php echo $this->BcForm->label('CuCustomFieldDefinition.field_name', 'フィールド名') ?>&nbsp;<span
 					class="required bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span>
 			</th>
 			<td class="col-input bca-form-table__input" colspan="3">
@@ -91,7 +91,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 				<?php echo $this->BcForm->error('CuCustomFieldDefinition.field_name') ?>
 				<?php if ($this->request->action == 'admin_edit'): ?>
 				<p>
-					<span id="BeforeFieldNameComment">変更前のフィールド定義名：</span>
+					<span id="BeforeFieldNameComment">変更前のフィールド名：</span>
 					<span id="BeforeFieldName"><?php echo $this->BcForm->value('CuCustomFieldDefinition.field_name') ?></span>
 				</p>
 				<?php endif ?>
@@ -102,7 +102,7 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 		</tr>
 		<tr id="Row<?php echo $currentModelName . Inflector::camelize('name'); ?>">
 			<th class="col-head bca-form-table__label">
-				<?php echo $this->BcForm->label('CuCustomFieldDefinition.name', '入力欄ラベル') ?>&nbsp;<span
+				<?php echo $this->BcForm->label('CuCustomFieldDefinition.name', 'フィールド定義名') ?>&nbsp;<span
 					class="required bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span>
 			</th>
 			<td class="col-input bca-form-table__input" colspan="3">

--- a/View/Elements/admin/cu_custom_field_definitions/index_list.php
+++ b/View/Elements/admin/cu_custom_field_definitions/index_list.php
@@ -18,7 +18,7 @@ $this->BcBaser->css(array(
 	'//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css',
 	'CuCustomField.admin/cu_custom_field',
 ));
-$this->BcListTable->setColumnNumber(9);
+$this->BcListTable->setColumnNumber(6);
 $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 ?>
 
@@ -40,23 +40,13 @@ $contentName = $this->BcText->arrayValue($contentId, $blogContentDatas);
 <thead class="bca-table-listup__thead">
 	<tr>
 		<th class="bca-table-listup__thead-th"><?php // No ?>
-		<?php
-		echo $this->Paginator->sort('no',
-			[
-				'asc' => '<i class="bca-icon--asc"></i>' . __d('baser', 'No'),
-				'desc' => '<i class="bca-icon--desc"></i>' . __d('baser', 'No')
-			],
-			[
-				'escape' => false,
-				'class' => 'btn-direction bca-table-listup__a'
-			]);
-			?>
+			No
 		</th>
-		<th class="bca-table-listup__thead-th"><?php // カスタムフィールド名 ?>
+		<th class="bca-table-listup__thead-th"><?php // フィールド定義名 ?>
 			フィールド定義名
 		</th>
-		<th class="bca-table-listup__thead-th"><?php // フィールド名 ?>
-			フィールド名
+		<th class="bca-table-listup__thead-th"><?php // 入力欄ラベル ?>
+			入力欄ラベル
 		</th>
 		<th class="bca-table-listup__thead-th"><?php // フィールドタイプ ?>
 			フィールドタイプ

--- a/View/Elements/admin/cu_custom_field_definitions/index_row.php
+++ b/View/Elements/admin/cu_custom_field_definitions/index_row.php
@@ -29,9 +29,9 @@ $class = ' class="' . implode(' ', $classies) . '"';
 	<td class="bca-table-listup__tbody-td bca-table-listup__tbody-td--no"><?php // No ?>
 		<?php echo $data['CuCustomFieldDefinition']['id']; ?>
 	</td>
-	<td class="bca-table-listup__tbody-td bca-table-listup__tbody-td--title"><?php // タイトル ?>
+	<td class="bca-table-listup__tbody-td bca-table-listup__tbody-td--title"><?php // フィールド定義名 ?>
 		<?php
-		$this->BcBaser->link($data['CuCustomFieldDefinition']['name'],
+		$this->BcBaser->link($data['CuCustomFieldDefinition']['field_name'],
 			[
 				'controller' => 'cu_custom_field_definitions',
 				'action' => 'edit',
@@ -43,8 +43,8 @@ $class = ' class="' . implode(' ', $classies) . '"';
 			]);
 		?>
 	</td>
-	<td class="bca-table-listup__tbody-td bca-table-listup__tbody-td--hasCustomField"><?php // フィールド名 ?>
-		<?php echo $data['CuCustomFieldDefinition']['field_name'] ?>
+	<td class="bca-table-listup__tbody-td bca-table-listup__tbody-td--hasCustomField"><?php // 入力欄ラベル ?>
+		<?php echo h($data['CuCustomFieldDefinition']['name']); ?>
 	</td>
 	<td class="bca-table-listup__tbody-td bca-table-listup__tbody-td--hasCustomField"><?php // フィールドタイプ ?>
 		<?php


### PR DESCRIPTION
issueはこちらです。
https://github.com/ecatchup/CuCustomField/issues/41

■ 調整前
https://user-images.githubusercontent.com/1115768/242828554-cc900090-0f50-4c7e-afaa-a610560df49b.png

■ 調整後
![after](https://github.com/ecatchup/CuCustomField/assets/1115768/efadf9f9-c501-4175-b2d2-f5d80430b9e0)

