### PR TITLE
カスタムフィールド設定一覧に表示件数調整リンクを備え、他不都合を修正

### DIFF
--- a/Controller/CuCustomFieldConfigsController.php
+++ b/Controller/CuCustomFieldConfigsController.php
@@ -68,6 +68,11 @@ class CuCustomFieldConfigsController extends CuCustomFieldAppController
 
 		$this->set('datas', $this->paginate('CuCustomFieldConfig'));
 		$this->set('blogContentDatas', ['0' => '指定しない'] + $this->blogContentDatas);
+
+		if ($this->RequestHandler->isAjax() || !empty($this->params['url']['ajax'])) {
+			$this->render('ajax_index');
+			return;
+		}
 	}
 
 	/**
@@ -169,38 +174,19 @@ class CuCustomFieldConfigsController extends CuCustomFieldAppController
 	protected function _createAdminIndexConditions($data)
 	{
 		$conditions = [];
-		$blogContentId = '';
 
 		if (isset($data['CuCustomFieldConfig']['content_id'])) {
-			$blogContentId = $data['CuCustomFieldConfig']['content_id'];
+			$conditions['CuCustomFieldConfig.content_id'] = $data['CuCustomFieldConfig']['content_id'];
 		}
 
-		unset($data['_Token']);
-		unset($data['CuCustomFieldConfig']['content_id']);
-
-		// 条件指定のないフィールドを解除
-		if (!empty($data['CuCustomFieldConfig'])) {
-			foreach($data['CuCustomFieldConfig'] as $key => $value) {
-				if ($value === '') {
-					unset($data['CuCustomFieldConfig'][$key]);
-				}
-			}
-			if ($data['CuCustomFieldConfig']) {
-				$conditions = $this->postConditions($data);
-			}
+		if (isset($data['CuCustomFieldConfig']['status']) && $data['CuCustomFieldConfig']['status'] === '') {
+			unset($data['CuCustomFieldConfig']['status']);
+		}
+		if (isset($data['CuCustomFieldConfig']['status'])) {
+			$conditions['CuCustomFieldConfig.status'] = $data['CuCustomFieldConfig']['status'];
 		}
 
-		if ($blogContentId) {
-			$conditions = [
-				'CuCustomFieldConfig.content_id' => $blogContentId
-			];
-		}
-
-		if ($conditions) {
-			return $conditions;
-		} else {
-			return [];
-		}
+		return $conditions;
 	}
 
 }

--- a/View/CuCustomFieldConfigs/admin/ajax_index.php
+++ b/View/CuCustomFieldConfigs/admin/ajax_index.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * CuCustomField : baserCMS Custom Field
+ * Copyright (c) Catchup, Inc. <https://catchup.co.jp>
+ *
+ * @copyright        Copyright (c) Catchup, Inc.
+ * @link             https://catchup.co.jp
+ * @package          CuCustomField.View
+ * @license          MIT LICENSE
+ */
+$this->BcBaser->element('cu_custom_field_configs/index_list');

--- a/View/Elements/admin/cu_custom_field_configs/index_list.php
+++ b/View/Elements/admin/cu_custom_field_configs/index_list.php
@@ -112,6 +112,6 @@ $this->BcListTable->setColumnNumber(9);
     <!-- pagination -->
     <?php $this->BcBaser->element('pagination') ?>
     <!-- list-num -->
-    <?php //$this->BcBaser->element('list_num') ?>
+    <?php $this->BcBaser->element('list_num') ?>
   </div>
 </div>


### PR DESCRIPTION
issueはこちらです。
https://github.com/ecatchup/CuCustomField/issues/42

追加した件数指定表示はこちら。
![sc_configs_index](https://github.com/ecatchup/CuCustomField/assets/1115768/6c55cadc-4e80-445d-b1f0-e8e2421632dc)


他不都合として、カスタムフィールド設定一覧の検索が正しく動作していなかったため調整入れました。
