### PR TITLE
fix #45 公開側ブログ記事一覧画面でファイルアップロードに登録した画像パスが取得できない

### DIFF
--- a/Plugin/CuCfFile/Event/CuCfFileControllerEventListener.php
+++ b/Plugin/CuCfFile/Event/CuCfFileControllerEventListener.php
@@ -31,7 +31,7 @@ class CuCfFileControllerEventListener extends BcControllerEventListener {
 	 * @param CakeEvent $event
 	 */
 	public function startup(CakeEvent $event) {
-		if(!$this->isAction(['BlogPosts.AdminAdd', 'BlogPosts.AdminEdit', 'BlogPosts.AdminDelete', 'Blog.Archives'])) {
+		if(!$this->isAction(['BlogPosts.AdminAdd', 'BlogPosts.AdminEdit', 'BlogPosts.AdminDelete', 'Blog.Archives', 'Blog.Index'])) {
 			return;
 		}
 		$controller = $event->subject();


### PR DESCRIPTION
ブログ記事一覧画面のアクション（Blog.Index）のときに、
CuCfFileBehaviorの読み込み処理がなされていなかったので、対象アクションに入れることで、
CuCfFileBehaviorの __constructで行っているパス情報の定義が成されることで解消しています。

