### PR TITLE
fix #46 ファイルアップロードに登録した画像が強制的に1000pxサイズにリサイズされている動作を修正

### DIFF
--- a/Plugin/CuCfFile/Model/Behavior/CuCfFileBehavior.php
+++ b/Plugin/CuCfFile/Model/Behavior/CuCfFileBehavior.php
@@ -164,9 +164,9 @@ class CuCfFileBehavior extends ModelBehavior
 								'type' => 'all',
 								'namefield' => 'no',
 								'nameformat' => '%08d',
-								'imageresize'  => ['width' => 1000, 'height' => 1000, 'thumb' => false],
 								'imagecopy' => [
-									'thumb' => ['suffix' => '_thumb', 'width' => 300, 'height' => 300]
+									'large' => ['suffix' => '_large', 'width' => 1000, 'height' => 1000],
+									'thumb' => ['suffix' => '_thumb', 'width' => 300, 'height' => 300],
 								]
 							];
 						}
@@ -269,9 +269,9 @@ class CuCfFileBehavior extends ModelBehavior
 						'type' => 'all',
 						'namefield' => 'no',
 						'nameformat' => '%08d',
-						'imageresize' => ['width' => 1000, 'height' => 1000],
 						'imagecopy' => [
-							'thumb' => ['suffix' => '_thumb', 'width' => 300, 'height' => 300]
+							'large' => ['suffix' => '_large', 'width' => 1000, 'height' => 1000],
+							'thumb' => ['suffix' => '_thumb', 'width' => 300, 'height' => 300],
 						]
 					];
 				}


### PR DESCRIPTION
ファイルアップロード欄に1000pxサイズ以上で登録した画像が、強制的に1000pxにリサイズされた大きさで保存されることで、1000px以上の画像が利用できないため、1000pxはサムネイル定義とし、オリジナル画像を保存する動作に調整しました。
